### PR TITLE
feat: only track stable flatpak version

### DIFF
--- a/org.kde.discover.yaml
+++ b/org.kde.discover.yaml
@@ -213,7 +213,7 @@ modules:
             tag: 1.18.0
             x-checker-data:
               type: git
-              tag-pattern: ^([\d.]+)$
+              tag-pattern: ^(1\.[0-8][02468]\..*)$
               is-important: true
 
         modules:


### PR DESCRIPTION
We probably shouldn't use the pre-release, pre-releases aren't marked as such in anitya, so have to use git